### PR TITLE
Added a feature where you can manually set the temp files folder.

### DIFF
--- a/OpenHtmlToPdf.Tests/HtmlToPdfConversion.cs
+++ b/OpenHtmlToPdf.Tests/HtmlToPdfConversion.cs
@@ -190,7 +190,7 @@ namespace OpenHtmlToPdf.Tests
 
             Pdf.From(html).Content();
 
-            Assert.AreEqual(0, Directory.GetFiles(Path.Combine(Path.GetTempPath(), "OpenHtmlToPdf"), "*.pdf").Count());
+            Assert.AreEqual(0, Directory.GetFiles(Path.Combine(TemporaryPdf.GetTempPath(), "OpenHtmlToPdf"), "*.pdf").Count());
         }
 
         [TestMethod]

--- a/OpenHtmlToPdf.WkHtmlToPdf/Assets/BundledFile.cs
+++ b/OpenHtmlToPdf.WkHtmlToPdf/Assets/BundledFile.cs
@@ -61,7 +61,7 @@ namespace OpenHtmlToPdf.WkHtmlToPdf.Assets
 
         private static string BundledFilesDirectory()
         {
-            return Path.Combine(Path.GetTempPath(), "OpenHtmlToPdf", Version());
+            return Path.Combine(Program.TempDir ?? Path.GetTempPath(), "OpenHtmlToPdf", Version());
         }
 
         private static string Version()

--- a/OpenHtmlToPdf.WkHtmlToPdf/Program.cs
+++ b/OpenHtmlToPdf.WkHtmlToPdf/Program.cs
@@ -2,16 +2,22 @@
 using System.IO;
 using System.Runtime.Serialization.Json;
 using System.Text;
+using System.Text.RegularExpressions;
 using OpenHtmlToPdf.WkHtmlToPdf.WkHtmlToX;
 
 namespace OpenHtmlToPdf.WkHtmlToPdf
 {
     static class Program
     {
-        static int Main()
+        internal static string TempDir { private set; get; }
+
+        static int Main(string[] args)
         {
             try
             {
+                if (args.Length > 0)
+                    ParseArguments(args);
+
                 ConvertStandardInputToPdf();
 
                 return 0;
@@ -21,6 +27,36 @@ namespace OpenHtmlToPdf.WkHtmlToPdf
                 WriteExceptionMessageToStandardError(ex);
 
                 return -1;
+            }
+        }
+
+        /// <summary>
+        /// Parses the programs arguments.
+        /// </summary>
+        private static void ParseArguments(string[] args)
+        {
+            Regex argument = new Regex(@"^-([^=]+)=(.+)$");
+
+            for (int i = 0; i < args.Length; i++)
+            {
+                Match arg = argument.Match(args[i]);
+                if (arg.Success)
+                {
+                    string
+                        name = arg.Groups[1].Value,
+                        value = arg.Groups[2].Value;
+
+                    switch (name.ToUpper())
+                    {
+                        case "TEMPDIR":
+                            TempDir = value;
+                            break;
+                    }
+                }
+                else
+                {
+                    throw new Exception($"Failed to parse argument \"{args[i]}\"");
+                }
             }
         }
 

--- a/OpenHtmlToPdf/Assets/ConverterExecutable.cs
+++ b/OpenHtmlToPdf/Assets/ConverterExecutable.cs
@@ -75,7 +75,7 @@ namespace OpenHtmlToPdf.Assets
 
         private static string BundledFilesDirectory()
         {
-            return Path.Combine(Path.GetTempPath(), "OpenHtmlToPdf", Version());
+            return Path.Combine(TemporaryPdf.GetTempPath(), "OpenHtmlToPdf", Version());
         }
 
         private static string Version()

--- a/OpenHtmlToPdf/HtmlToPdfConverterProcess.cs
+++ b/OpenHtmlToPdf/HtmlToPdfConverterProcess.cs
@@ -70,7 +70,8 @@ namespace OpenHtmlToPdf
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 UseShellExecute = false,
-                CreateNoWindow = true
+                CreateNoWindow = true,
+                Arguments = TemporaryPdf.TempFilesPath == null ? null : $"\"-TEMPDIR={TemporaryPdf.TempFilesPath}\""
             };
         }
 

--- a/OpenHtmlToPdf/Properties/AssemblyInfo.cs
+++ b/OpenHtmlToPdf/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.12.0")]
-[assembly: AssemblyFileVersion("1.12.0")]
+[assembly: AssemblyVersion("1.13.0.0")]
+[assembly: AssemblyFileVersion("1.13.0.0")]

--- a/OpenHtmlToPdf/TemporaryPdf.cs
+++ b/OpenHtmlToPdf/TemporaryPdf.cs
@@ -5,6 +5,11 @@ namespace OpenHtmlToPdf
 {
     public static class TemporaryPdf
     {
+        /// <summary>
+        /// Setting this value overrides the default value for the temporary files folder.
+        /// </summary>
+        public static string TempFilesPath { set; get; }
+
         public static byte[] ReadTemporaryFileContent(string temporaryFilename)
         {
             using (var temporaryFile = new FileStream(temporaryFilename, FileMode.Open, FileAccess.Read))
@@ -32,9 +37,11 @@ namespace OpenHtmlToPdf
             }
         }
 
+        public static string GetTempPath() => TempFilesPath ?? Path.GetTempPath();
+
         public static string TemporaryFilePath()
         {
-            return Path.Combine(Path.GetTempPath(), "OpenHtmlToPdf", TemporaryFilename());
+            return Path.Combine(GetTempPath(), "OpenHtmlToPdf", TemporaryFilename());
         }
 
         private static string TemporaryFilename()


### PR DESCRIPTION
Hello,

I was using this project on an IIS server and due to security reasons the program wasn't allowed to access the `C:\Windows\Temp\` folder that `Path.GetTempPath()` defaults to. I added a string property `TemporaryPdf.TempFilesPath` that can be set to override the default path.

This is my first pull request, ever. 