### PR TITLE
Add WithoutCompression fluent method

### DIFF
--- a/OpenHtmlToPdf.Tests/HtmlToPdfConversion.cs
+++ b/OpenHtmlToPdf.Tests/HtmlToPdfConversion.cs
@@ -127,15 +127,31 @@ namespace OpenHtmlToPdf.Tests
         }
 
         [TestMethod]
-        public void Compressed()
+        public void With_compression()
         {
             const string expectedDocumentContent = "Expected document content";
+            const int expectedContentSize = 7922;
 
             var html = string.Format(HtmlDocumentFormat, expectedDocumentContent);
 
-            var result = Pdf.From(html).Comressed().Content();
+            var result = Pdf.From(html).WithCompression().Content();
 
             TextAssert.AreEqual(expectedDocumentContent, PdfDocumentReader.ToText(result));
+            Assert.AreEqual(expectedContentSize, result.Length);
+        }
+
+        [TestMethod]
+        public void Without_compression()
+        {
+            const string expectedDocumentContent = "Expected document content";
+            const int expectedContentSize = 17880;
+
+            var html = string.Format(HtmlDocumentFormat, expectedDocumentContent);
+
+            var result = Pdf.From(html).WithoutCompression().Content();
+
+            TextAssert.AreEqual(expectedDocumentContent, PdfDocumentReader.ToText(result));
+            Assert.AreEqual(expectedContentSize, result.Length);
         }
 
         [TestMethod]

--- a/OpenHtmlToPdf/FluentSettings.cs
+++ b/OpenHtmlToPdf/FluentSettings.cs
@@ -5,9 +5,20 @@ namespace OpenHtmlToPdf
 {
     public static class FluentSettings
     {
+        [Obsolete]
         public static IPdfDocument Comressed(this IPdfDocument pdfDocument)
         {
+            return WithCompression(pdfDocument);
+        }
+
+        public static IPdfDocument WithCompression(this IPdfDocument pdfDocument)
+        {
             return pdfDocument.WithGlobalSetting("useCompression", "true");
+        }
+
+        public static IPdfDocument WithoutCompression(this IPdfDocument pdfDocument)
+		{
+            return pdfDocument.WithGlobalSetting("useCompression", "false");
         }
 
         public static IPdfDocument WithTitle(this IPdfDocument pdfDocument, string title)

--- a/OpenHtmlToPdf/Properties/AssemblyInfo.cs
+++ b/OpenHtmlToPdf/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.12.0")]
-[assembly: AssemblyFileVersion("1.12.0")]
+[assembly: AssemblyVersion("1.13.0")]
+[assembly: AssemblyFileVersion("1.13.0")]

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ OpenHtmlToPdf can be download as a [NuGet package] (https://www.nuget.org/packag
 		.WithoutOutline()
 		.WithMargins(1.25.Centimeters())
 		.Portrait()
-		.Comressed()
+		.WithCompression()
 		.Content();
 
 ### Defining wkhtmltopdf settings directly ###


### PR DESCRIPTION
Add WithoutCompression fluent method along with counterpart WithCompression to replace the existing Comression [sic] method, which contained a typo and is now marked obsolete. The WithoutCompression method is useful because compression will in fact be used by default.